### PR TITLE
#5 incorrect placement of comma after null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function(doc) {
 			return '<span class="json-markup-number">'+obj+'</span>';
 
 			case 'null':
-			return '<span class="json-markup-null">null</span>\n';
+			return '<span class="json-markup-null">null</span>';
 
 			case 'string':
 			return '<span class="json-markup-string">"'+escape(obj.replace(/\n/g, '\n'+indent))+'"</span>';


### PR DESCRIPTION
```javascript
jsonMarkup({ val1: null, val2: null})
```
produces incorrect placement of comma:
```javascript
{
    val1: null
,
    val2: null

}
```
should produce:
```javascript
{
    val1: null,
    val2: null
}
```