### PR TITLE
Avoid to pass undefined or null object to Object.keys()

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var INDENT = '    '
 
 function inlineRule (objRule) {
   var str = ''
-  Object.keys(objRule).forEach(function (rule) {
+  objRule && Object.keys(objRule).forEach(function (rule) {
     str += rule + ':' + objRule[rule] + ';'
   })
   return str


### PR DESCRIPTION
If css file doesn't has some of those style classes, the "objRule" would be undefined.