### PR TITLE
Symbols, such as '[]{}', must not be included between html tags.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,14 +77,14 @@ module.exports = function (doc, styleFile) {
         return '<span ' + style('json-markup-string') + '>"<a href="' + escape(obj) + '">' + escape(obj) + '</a>"</span>'
 
       case 'array':
-        return forEach(obj, '[', ']', visit)
+        return forEach(obj, '', '', visit)
 
       case 'object':
         var keys = Object.keys(obj).filter(function (key) {
           return obj[key] !== undefined
         })
 
-        return forEach(keys, '{', '}', function (key) {
+        return forEach(keys, '', '', function (key) {
           return '<span ' + style('json-markup-key') + '>"' + key + '":</span> ' + visit(obj[key])
         })
     }


### PR DESCRIPTION
Symbols, such as '[]{}', must not be included between html tags.